### PR TITLE
Perf/stage performance improve

### DIFF
--- a/src/components/Bar.tsx
+++ b/src/components/Bar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import * as THREE from 'three';
 import { useFrame } from '@react-three/fiber';
 import { lerp } from 'three/src/math/MathUtils';
@@ -16,12 +16,11 @@ type Props = {
 
 export default function Bar({ radius, index, centerPos, position, theta, color, meanRef, dataArrayRef }: Props) {
   const barRef = useRef<THREE.Mesh>(null!);
-  const [angle, setAngle] = useState(theta);
   const heightRef = useRef(0);
   const angleRef = useRef(theta);
   const radian = Math.PI / 180;
 
-  useFrame((_, delta) => {
+  useFrame((_) => {
     if (!dataArrayRef.current) return;
     const mean = meanRef.current - 1;
     const frequency = dataArrayRef.current?.[index] / 128 - 1;
@@ -32,12 +31,11 @@ export default function Bar({ radius, index, centerPos, position, theta, color, 
     } else {
       heightRef.current = height - height * 0.2;
     }
-    const nextAngle = (angleRef.current + radian) % 360;
-    angleRef.current = nextAngle;
+    angleRef.current = (angleRef.current + radian) % 360;
     const power = mean < 0 ? 0 : Math.round(mean * 10000) / 10000;
-    const nx = centerPos[0] + (radius + power * 500) * Math.cos(angle);
+    const nx = centerPos[0] + (radius + power * 500) * Math.cos(angleRef.current);
     const ny = centerPos[1] + heightRef.current * heightRef.current * 1200;
-    const nz = centerPos[2] + (radius + power * 500) * Math.sin(angle);
+    const nz = centerPos[2] + (radius + power * 500) * Math.sin(angleRef.current);
 
     barRef.current.position.x = lerp(barRef.current.position.x, nx, 0.02);
     barRef.current.position.y = lerp(barRef.current.position.y, ny, 0.03);

--- a/src/components/Bar.tsx
+++ b/src/components/Bar.tsx
@@ -5,33 +5,38 @@ import { lerp } from 'three/src/math/MathUtils';
 
 type Props = {
   radius: number;
+  index: number;
   centerPos: number[];
-  mean: number;
-  musicInput: number;
   position: THREE.Vector3;
   theta: number;
   color: string;
+  meanRef: React.MutableRefObject<number>;
+  dataArrayRef: React.MutableRefObject<Uint8Array | null>;
 };
 
-export default function Bar({ radius, centerPos, mean, musicInput, position, theta, color }: Props) {
+export default function Bar({ radius, index, centerPos, position, theta, color, meanRef, dataArrayRef }: Props) {
   const barRef = useRef<THREE.Mesh>(null!);
-  const [height, setHeight] = useState(0);
-  const [angle, setAngle] = useState<any>(theta);
-
+  const [angle, setAngle] = useState(theta);
+  const heightRef = useRef(0);
+  const angleRef = useRef(theta);
   const radian = Math.PI / 180;
 
   useFrame((_, delta) => {
-    if (musicInput > height) {
-      setHeight(musicInput);
-    } else {
-      setHeight(height - height * 0.2);
-    }
+    if (!dataArrayRef.current) return;
+    const mean = meanRef.current - 1;
+    const frequency = dataArrayRef.current?.[index] / 128 - 1;
+    const height = heightRef.current;
 
-    const na = (angle + radian) % 360;
-    setAngle(na);
+    if (frequency > height) {
+      heightRef.current = frequency;
+    } else {
+      heightRef.current = height - height * 0.2;
+    }
+    const nextAngle = (angleRef.current + radian) % 360;
+    angleRef.current = nextAngle;
     const power = mean < 0 ? 0 : Math.round(mean * 10000) / 10000;
     const nx = centerPos[0] + (radius + power * 500) * Math.cos(angle);
-    const ny = centerPos[1] + height * height * 1200;
+    const ny = centerPos[1] + heightRef.current * heightRef.current * 1200;
     const nz = centerPos[2] + (radius + power * 500) * Math.sin(angle);
 
     barRef.current.position.x = lerp(barRef.current.position.x, nx, 0.02);

--- a/src/components/MusicAnalyzer.tsx
+++ b/src/components/MusicAnalyzer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import Bar from './Bar';
@@ -13,8 +13,10 @@ type Props = {
 
 export default function MusicAnalyzer({ music, fftSize, centerPos, radius }: Props) {
   const [analyser, setAnalyser] = useState<any>(null);
-  const [dataArray, setDataArray] = useState<any>(null);
-  const [mean, setMean] = useState(0);
+  const dataArrayRef = useRef<Uint8Array | null>(null);
+  const meanRef = useRef(0);
+  // const [dataArray, setDataArray] = useState<any>(null);
+  // const [mean, setMean] = useState(0);
   const [sourceNode, setSourceNode] = useState<MediaElementAudioSourceNode | null>(null);
   const isMusicPlay = useMusicPlayStore((state) => state.isMusicPlay);
 
@@ -46,26 +48,31 @@ export default function MusicAnalyzer({ music, fftSize, centerPos, radius }: Pro
     setAnalyser(analyser);
   }, [isMusicPlay]);
 
+  const newData = new Uint8Array(fftSize);
   useFrame(() => {
     if (analyser) {
-      const newData = new Uint8Array(fftSize);
-
       analyser.getByteTimeDomainData(newData);
 
-      setMean(newData.reduce((a, b) => a + b) / (128 * newData.length));
-      setDataArray(newData);
+      // setMean(newData.reduce((a, b) => a + b) / (128 * newData.length));
+      // setDataArray(newData);
+
+      meanRef.current = newData.reduce((a, b) => a + b) / (128 * newData.length);
+      dataArrayRef.current = newData;
     }
   });
-  if (isMusicPlay && dataArray) {
+  if (isMusicPlay) {
     return (
       <group>
         {bars.map((item, index) => (
           <Bar
             key={index}
+            index={index}
             radius={radius}
             centerPos={centerPos}
-            mean={mean - 1}
-            musicInput={dataArray[index] / 128 - 1}
+            // mean={mean - 1}
+            // musicInput={dataArray[index] / 128 - 1}
+            dataArrayRef={dataArrayRef}
+            meanRef={meanRef}
             position={item.position}
             theta={item.theta}
             color={item.color}


### PR DESCRIPTION
## Stage에서 브라우저가 작동을 멈추거나 느려지는 현상 해결

stage에서 브라우저가 멈춤이 잦아서  performance를 브라우저에서 확인해보았을 때 re-rendering으로 인해 scripting이 과도하게 많이 일어나는 문제를 발견.
코드를 다시 분석해봤을 때, useFrame 내부에서 setState를 실행하고 이에 따라 컴포넌트가 매 프레임마다 렌더링되고 있었습니다.
이를 방지하기 위해서 setState를 통해 state를 변경하는 대신, 값을 변경하여도 리렌더링이 일어나지 않는 useRef를 사용하여 성능 개선을 진행하였습니다

---

`성능 개선 전`


![](https://velog.velcdn.com/images/woohobi/post/2e8cc568-af55-4dcc-bc4c-6f7f1e0af1d7/image.png)

`성능 개선 후`


![](https://velog.velcdn.com/images/woohobi/post/bc5ffbf9-b32a-4b28-bc14-5109df55390a/image.png)




### 성능 비교
1번과 2번 테스트 모두 약 10초 동안의 3d 렌더링 성능을 테스트해보았습니다
1번은 10.01초 동안 script를 처리하는데 걸린 시간이 9636ms 이고, 2번 테스트는 10.38초 동안 2280ms가 걸린 것을 확인하였습니다
> 동일 시간 기준: 개선 전 => 개선후 약 scripting 77% 감소
