### PR TITLE
perf: 3d stage prefetch

### DIFF
--- a/src/components/Music.tsx
+++ b/src/components/Music.tsx
@@ -36,12 +36,18 @@ const MusicAlbum = ({ music, index, handleClick, groupY, selectedMusic, musics, 
   const router = useRouter();
 
   const handlePlayMusic = (event: React.MouseEvent<HTMLButtonElement>) => {
-    // event.pr\
-    event.stopPropagation();
-    if (selectedMusic?.id !== music.id) return;
+    if (!selectedMusic) return;
     setIsMusicPlay(true);
     router.push('/stage');
+    event.stopPropagation();
   };
+
+  useEffect(() => {
+    //TODO: 앨범 dynamic page를 구현하면 prefetch를 각 페이지별로 아래 옵션 중에서 구현
+    // 1.앨범에 마우스가 hover 되었을 경우
+    // 2 앨범이 선택되었을 경우
+    router.prefetch('/stage');
+  }, [router]);
 
   const updateRotation = ({ x, y, z }: MeshAxis) => {
     meshRef.current.rotation.x = lerp(meshRef.current.rotation.x, x, LERP_FACTOR);
@@ -98,8 +104,8 @@ const MusicAlbum = ({ music, index, handleClick, groupY, selectedMusic, musics, 
     <mesh
       ref={meshRef}
       onClick={(e) => {
-        e.stopPropagation();
         handleClick(music.id);
+        e.stopPropagation();
       }}
     >
       <Html>


### PR DESCRIPTION
## music 페이지에서 stage prefetch

로직을 처리해야 해서 <Link>를 사용하지 못하는 상황
router를 이용해서 /stage를 prefetch를 진행하였습니다.


### TODO
추후, stage가 앨범 별로 나뉘게 되면 추가 최적화 필요(모든 경로를 prefetching 할 필요가 없으니!)
앨범 선택시, 또는 앨범 hover시 해당 앨범 prefetch 고려