### PR TITLE
Feat/search-error-handling

### DIFF
--- a/src/components/MusicSearch.tsx
+++ b/src/components/MusicSearch.tsx
@@ -2,10 +2,12 @@ import Image from 'next/image';
 import { useMusicSearch } from '@/hooks/queries/music/useMusics';
 import { cn } from '@/lib/utils';
 import { MusicUpload, YoutubeMusic } from '@/types/music';
-import { RefreshCwIcon, XIcon } from 'lucide-react';
+import { XIcon } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
-import { Suspense, useState } from 'react';
+import { useState } from 'react';
 import { Input } from '@/components/ui/input';
+import { SearchFallback } from '@/components/error-boundary/fallback/SearchFallback';
+import ApiErrorBoundary from '@/components/error-boundary/ApiBoundary';
 
 type Props = {
   updateSelectedTrack: (track: YoutubeMusic) => void;
@@ -15,7 +17,6 @@ type Props = {
 function MusicSearch({ updateSelectedTrack, selectedTrack }: Props) {
   const [musicKeyword, setMusicKeyword] = useState('');
   const debouncedKeyword = useDebounce(musicKeyword, 200);
-  const { data, isError, refetch } = useMusicSearch(debouncedKeyword);
 
   const handleSearchMusic = (e: React.ChangeEvent<HTMLInputElement>) => {
     setMusicKeyword(e.target.value);
@@ -37,42 +38,42 @@ function MusicSearch({ updateSelectedTrack, selectedTrack }: Props) {
           </button>
         )}
       </div>
-        <ul
-          className={cn('flex max-h-[175px] flex-col overflow-y-scroll  border-zinc-300', {
-            'border-b-[1px]': data?.length
+      <ApiErrorBoundary renderFallback={SearchFallback} resetKeys={[debouncedKeyword]}>
+        <MusicList updateSelectedTrack={updateSelectedTrack} selectedTrack={selectedTrack} keyword={debouncedKeyword} />
+      </ApiErrorBoundary>
+    </section>
+  );
+}
+
+type MusicSearchProps = Props & {
+  keyword: string;
+};
+
+function MusicList({ updateSelectedTrack, selectedTrack, keyword }: MusicSearchProps) {
+  const { data } = useMusicSearch(keyword);
+
+  return (
+    <ul
+      className={cn('flex max-h-[175px] flex-col overflow-y-scroll  border-zinc-300', {
+        'border-b-[1px]': data?.length
+      })}
+    >
+      {data?.map((track) => (
+        <li
+          key={track.id}
+          onClick={() => updateSelectedTrack(track)}
+          className={cn('flex h-[70px] gap-x-3.5 rounded-sm border-b-[1px] py-3 pl-3 hover:bg-gray-200', {
+            'bg-gray-200': selectedTrack?.id === track.id
           })}
         >
-          {data?.map((track) => (
-            <li
-              key={track.id}
-              onClick={() => updateSelectedTrack(track)}
-              className={cn('flex h-[70px] gap-x-3.5 rounded-sm border-b-[1px] py-3 pl-3 hover:bg-gray-200', {
-                'bg-gray-200': selectedTrack?.id === track.id
-              })}
-            >
-              <Image
-                className="rounded-md object-contain"
-                width={50}
-                height={50}
-                src={track.thumbnail}
-                alt="album-cover"
-              />
-              <div className="break-keep">
-                <h5 className="text-sm font-semibold">{track.parsed_artist}</h5>
-                <span className="line-clamp-1 text-sm">{track.parsed_title}</span>
-              </div>
-            </li>
-          ))}
-        </ul>
-      {isError && (
-        <div className="relative flex h-20 w-full items-center justify-center gap-x-1 rounded-md bg-gray-100/[0.75]">
-          <span className="text-gray-400">No results</span>
-          <button type="button" onClick={() => refetch()}>
-            <RefreshCwIcon className="h-4 w-4  text-gray-400" />
-          </button>
-        </div>
-      )}
-    </section>
+          <Image className="rounded-md object-contain" width={50} height={50} src={track.thumbnail} alt="album-cover" />
+          <div className="break-keep">
+            <h5 className="text-sm font-semibold">{track.parsed_artist}</h5>
+            <span className="line-clamp-1 text-sm">{track.parsed_title}</span>
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/components/error-boundary/ApiBoundary.tsx
+++ b/src/components/error-boundary/ApiBoundary.tsx
@@ -1,0 +1,24 @@
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import ErrorBoundary from '@/components/error-boundary/ErrorBoundary';
+import { ComponentProps, Suspense } from 'react';
+import { useRouter } from 'next/router';
+
+type ErrorBoundaryProps = ComponentProps<typeof ErrorBoundary>;
+
+type Props = ErrorBoundaryProps & {
+  children: React.ReactNode;
+  pendingFallback?: React.ReactNode;
+};
+
+function ApiErrorBoundary({ children, pendingFallback, resetKeys, ...props }: Props) {
+  const { reset } = useQueryErrorResetBoundary();
+  const pathname = useRouter().pathname;
+
+  return (
+    <ErrorBoundary onReset={reset} resetKeys={[resetKeys ? resetKeys : pathname]} {...props}>
+      <Suspense fallback={pendingFallback}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}
+
+export default ApiErrorBoundary;

--- a/src/components/error-boundary/ErrorBoundary.tsx
+++ b/src/components/error-boundary/ErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import { Component, ReactNode } from 'react';
+
+type State = {
+  error: Error | null;
+};
+
+type Props = {
+  children: ReactNode;
+  renderFallback: (args: { error: Error; reset: () => void }) => ReactNode;
+  resetKeys?: unknown[];
+  onReset?: () => void;
+};
+
+const initialState: State = { error: null };
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = initialState;
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  resetErrorBoundary = () => {
+    console.log('resest');
+    this.setState(initialState);
+    this.props.onReset && this.props.onReset();
+  };
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.state.error === null) {
+      return;
+    }
+    if (JSON.stringify(prevProps.resetKeys) !== JSON.stringify(this.props.resetKeys)) {
+      this.resetErrorBoundary();
+    }
+  }
+
+  render() {
+    const { children, renderFallback } = this.props;
+    const { error } = this.state;
+
+    if (error !== null) {
+      return renderFallback({
+        error,
+        reset: this.resetErrorBoundary
+      });
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/error-boundary/ErrorBoundary.tsx
+++ b/src/components/error-boundary/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { compareShallowArray } from '@/utils/equality';
 import { Component, ReactNode } from 'react';
 
 type State = {
@@ -33,7 +34,8 @@ class ErrorBoundary extends Component<Props, State> {
     if (this.state.error === null) {
       return;
     }
-    if (JSON.stringify(prevProps.resetKeys) !== JSON.stringify(this.props.resetKeys)) {
+
+    if (compareShallowArray(prevProps.resetKeys, this.props.resetKeys)) {
       this.resetErrorBoundary();
     }
   }

--- a/src/components/error-boundary/fallback/SearchFallback.tsx
+++ b/src/components/error-boundary/fallback/SearchFallback.tsx
@@ -1,0 +1,16 @@
+import { RefreshCwIcon } from 'lucide-react';
+
+type Props = {
+  reset: () => void;
+};
+
+export function SearchFallback({ reset }: Props) {
+  return (
+    <div className="relative flex h-20 w-full items-center justify-center gap-x-1 rounded-md bg-gray-100/[0.75]">
+      <span className="text-gray-400">No results</span>
+      <button type="button" onClick={reset}>
+        <RefreshCwIcon className="h-4 w-4  text-gray-400" />
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/queries/music/useMusics.ts
+++ b/src/hooks/queries/music/useMusics.ts
@@ -47,6 +47,7 @@ export const useMusicSearch = (keyword: string) => {
     queryFn: () => fetchMusicFromYoutube({ keyword }),
     enabled: !!keyword,
     suspense: true,
+    useErrorBoundary: true,
     retry: 0
   });
 };

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -4,7 +4,7 @@ export const useDebounce = <T>(value: T, delay?: number): T => {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedValue(value), delay || 500);
+    const timer = setTimeout(() => setDebouncedValue(value), delay ?? 500);
 
     return () => {
       clearTimeout(timer);

--- a/src/utils/equality.ts
+++ b/src/utils/equality.ts
@@ -1,0 +1,6 @@
+export function compareShallowArray(arr1: unknown[] = [], arr2: unknown[] = []): boolean {
+  if (arr1.length !== arr2.length) return false;
+
+  const isEqual = arr1.every((item, index) => item === arr2[index]);
+  return isEqual;
+}


### PR DESCRIPTION
### 🎉 변경 사항

1. Api error boundary 추가
suspense와 error boundary를 함께 사용하는 컴포넌트
useQueryErrorResetBoundary를 이용해서 실패한 api 호출을 초기화해줍니다.

2. error-boundary

아직 error handling에 대한 이해 부족해서  react-error-boundary를 사용하는 대신에 커스텀 error-boundary를 만들어서 사용해보고 있습니다. 
reset을 선언적 또는 유저가 직접 클릭해서 에러 상태를 초기화 할 수 있게 설계하였습니다.

resetKeys를 이용시에, nested object를 사용하지 않고 있어서 shallow하게 key값을 비교하게 util 함수를 만들었습니다.

3. useDebounce 
delay값을 truthy check을 하고 있었는데, 0으로 delay값을 지정할 시 falsy로 값을 판단하게 되어서 nullish 체크를 해주게 변경했습니다.